### PR TITLE
2 cicd not running test in all enviroments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -8,7 +8,6 @@ jobs:
   test:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest]
         python-version: ['3.6', '3.7', '3.8', '3.9']


### PR DESCRIPTION
Changed tox.ini configuration so the whole test suit is run in each of the environments.

Command `fail-fast: false` ensures that the whole matrix is run and one failed pipeline doesn't cancel all the others. This way you can see that OS/python version fails.

I also recommend squash commits because there are a few commits with identical messages. 