### PR TITLE
Fixing the rounding implementation

### DIFF
--- a/chisel4ml/scala/main/Neuron.scala
+++ b/chisel4ml/scala/main/Neuron.scala
@@ -17,7 +17,6 @@ package chisel4ml
 
 import chisel3._
 import chisel3.util._
-import chisel4ml.QuantizationContext
 import chisel4ml.implicits._
 import chisel4ml.conv2d._
 
@@ -32,7 +31,7 @@ object Neuron {
   ): O = {
     val muls = VecInit((in.zip(weights)).map { case (i, w) => qc.mul(i, w) })
     val pAct = qc.add(muls)
-    val sAct = qc.shiftAndRound(pAct, shift)
+    val sAct = qc.shiftAndRoundStatic(pAct, shift)
     qc.actFn(sAct, thresh, outputBitwidth)
   }
 }
@@ -50,7 +49,7 @@ class DynamicNeuron[I <: Bits, W <: Bits, M <: Bits, A <: Bits, O <: Bits](
 
   val muls = VecInit((io.in.bits.zip(inWeights)).map { case (i, w) => qc.mul(i, w) })
   val pAct = qc.add(muls)
-  val sAct = qc.shiftAndRound(
+  val sAct = qc.shiftAndRoundDynamic(
     pAct,
     io.weights.bits.threshShift.shift,
     io.weights.bits.threshShift.shiftLeft

--- a/chisel4ml/scala/main/conv2d/InputDataMover.scala
+++ b/chisel4ml/scala/main/conv2d/InputDataMover.scala
@@ -36,7 +36,6 @@ class InputDataMover[I <: Bits](input: lbir.QTensor) extends Module {
   })
 
   val (elementCounter, elementCounterWrap) = Counter(0 until input.numParams, io.nextElement.fire)
-  val (_, channelCounterWrap) = Counter(0 until input.numActiveParams(depthwise = true), io.nextElement.fire)
   val (wordSelectCounter, wordSelectCounterWrap) = Counter(0 until input.paramsPerWord, io.nextElement.fire, io.start)
   val (addressCounter, _) = Counter(0 until input.memDepth, wordSelectCounterWrap, io.start)
 

--- a/chisel4ml/scala/main/conv2d/ShiftRegisterConvolver.scala
+++ b/chisel4ml/scala/main/conv2d/ShiftRegisterConvolver.scala
@@ -59,7 +59,7 @@ class ShiftRegisterConvolver[I <: Bits](l: Conv2DConfig) extends Module {
 
   io.nextElement.ready := io.inputActivationsWindow.ready && !io.channelDone
   // First condition: waiting for shift registers to initially fill up. Second: filter goes over the width of image. Third: backpressure from input data mover.
-  io.inputActivationsWindow.valid := (elementCounter >= numRegs.U) &&
+  io.inputActivationsWindow.valid := shiftRegistersFull &&
     (widthCounter <= (l.input.width - l.kernel.width).U) &&
     RegNext(io.nextElement.fire)
 }

--- a/chisel4ml/scala/main/core.scala
+++ b/chisel4ml/scala/main/core.scala
@@ -17,29 +17,33 @@ package chisel4ml
 
 import chisel3._
 import chisel3.util._
-import chisel4ml.util.{reluFn, saturateFnS, signFnS, signFnU}
+import chisel4ml.util._
 
 trait QuantizationContext[I <: Bits, W <: Bits, M <: Bits, A <: Bits, O <: Bits] extends Any {
-  def mul:   (I, W) => M
-  def add:   Vec[M] => A
-  def actFn: (A, A, Int) => O
+  def mul:           (I, W) => M
+  def add:           Vec[M] => A
+  def shiftAndRound: (A, Int) => A
+  def actFn:         (A, A, Int) => O
 }
 
 object BinarizedQuantizationContext extends QuantizationContext[Bool, Bool, Bool, UInt, Bool] {
   def mul = (i: Bool, w: Bool) => ~(i ^ w)
   def add = (x: Vec[Bool]) => PopCount(x.asUInt)
-  def actFn: (UInt, UInt, Int) => Bool = signFnU
+  def shiftAndRound: (UInt, Int) => UInt = shiftAndRoundUIntStatic
+  def actFn:         (UInt, UInt, Int) => Bool = signFnU
 }
 
 object BinaryQuantizationContext extends QuantizationContext[UInt, Bool, SInt, SInt, Bool] {
   def mul = (i: UInt, w: Bool) => Mux(w, i.zext, -(i.zext))
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = signFnS
 }
 
 object BinaryQuantizationComputeS extends QuantizationContext[SInt, Bool, SInt, SInt, Bool] {
   def mul = (i: SInt, w: Bool) => Mux(w, i, -i)
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = signFnS
 }
 
@@ -48,6 +52,7 @@ class UniformQuantizationContextSSU(act: (SInt, SInt, Int) => UInt)
     extends QuantizationContext[SInt, SInt, SInt, SInt, UInt] {
   def mul = (i: SInt, w: SInt) => i * w
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = act
 }
 
@@ -57,6 +62,7 @@ class UniformQuantizationComputeUSU(act: (SInt, SInt, Int) => UInt)
     extends QuantizationContext[UInt, SInt, SInt, SInt, UInt] {
   def mul = (i: UInt, w: SInt) => i * w
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = act
 }
 
@@ -66,6 +72,7 @@ class UniformQuantizationContextSSS(act: (SInt, SInt, Int) => SInt)
     extends QuantizationContext[SInt, SInt, SInt, SInt, SInt] {
   def mul = (i: SInt, w: SInt) => i * w
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = act
 }
 
@@ -76,6 +83,7 @@ class UniformQuantizationContextUSS(act: (SInt, SInt, Int) => SInt)
     extends QuantizationContext[UInt, SInt, SInt, SInt, SInt] {
   def mul = (i: UInt, w: SInt) => i * w
   def add = (x: Vec[SInt]) => x.reduceTree(_ +& _)
+  def shiftAndRound: (SInt, Int) => SInt = shiftAndRoundSIntStatic
   def actFn = act
 }
 

--- a/chisel4ml/scala/test/UtilityFunctionsTests.scala
+++ b/chisel4ml/scala/test/UtilityFunctionsTests.scala
@@ -1,0 +1,64 @@
+package chisel4ml.tests
+
+import _root_.chisel3._
+import chiseltest._
+import org.scalatest.flatspec.AnyFlatSpec
+import chisel4ml.util.shiftAndRound
+
+class RoundTestBed(inputWidth: Int, shift: Int) extends Module {
+  val in = IO(Input(SInt(inputWidth.W)))
+  val out = IO(Output(SInt()))
+
+  out := shiftAndRound(in, shift)
+}
+
+object UtilityFunctionsTests {
+  // This function models the rounding function in the quantized_bits quantization
+  // operator of QKeras.
+  def roundModel(value: Int, shift: Int): Int = {
+    val scale = Math.pow(2.toDouble, shift.toDouble)
+    (math.floor((value.abs / scale) + 0.5) * value.sign).toInt
+  }
+}
+
+class UtilityFunctionsTests extends AnyFlatSpec with ChiselScalatestTester {
+  behavior.of("utilities")
+  import UtilityFunctionsTests.roundModel
+  it should "Test rounding -88 -> -6 and -150 -> -9" in {
+    test(new RoundTestBed(14, -4)) { dut =>
+      dut.in.poke((87).S(14.W))
+      dut.out.expect(roundModel(87, 4).S)
+      dut.in.poke((88).S(14.W))
+      dut.out.expect(roundModel(88, 4).S)
+      dut.in.poke((89).S(14.W))
+      dut.out.expect(roundModel(89, 4).S)
+
+      dut.in.poke((-89).S(14.W))
+      dut.out.expect(roundModel(-89, 4).S)
+      dut.in.poke((-87).S(14.W))
+      dut.out.expect(roundModel(-87, 4).S)
+      dut.in.poke((-88).S(14.W))
+      dut.out.expect(roundModel(-88, 4).S)
+    /*assert(roundModel(-88, 4).S(14.W).litValue.toInt == -6)
+      dut.in.poke((-150).S(14.W))
+      dut.out.expect(roundModel(-150, 4).S)
+      assert(roundModel(-150, 4).S(14.W).litValue.toInt == -9)*/
+    }
+  }
+
+  val r = new scala.util.Random
+  r.setSeed(42L)
+  val numRandomTests = 500
+  val maxAccumulatorValue = 8191
+  for (_ <- 0 until numRandomTests) {
+    val isNegative = r.nextBoolean()
+    val value = if (isNegative) -r.nextInt(maxAccumulatorValue) else r.nextInt(maxAccumulatorValue)
+    val shift = r.nextInt(7)
+    it should s"Test random rounding value: $value, shift: $shift" in {
+      test(new RoundTestBed(14, -shift)) { dut =>
+        dut.in.poke(value.S(14.W))
+        dut.out.expect(roundModel(value, shift).S)
+      }
+    }
+  }
+}

--- a/chisel4ml/scala/test/UtilityFunctionsTests.scala
+++ b/chisel4ml/scala/test/UtilityFunctionsTests.scala
@@ -3,13 +3,14 @@ package chisel4ml.tests
 import _root_.chisel3._
 import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
-import chisel4ml.util.shiftAndRound
+import chisel4ml.util.shiftAndRoundSIntStatic
 
 class RoundTestBed(inputWidth: Int, shift: Int) extends Module {
   val in = IO(Input(SInt(inputWidth.W)))
   val out = IO(Output(SInt()))
 
-  out := shiftAndRound(in, shift)
+  //out := shiftAndRoundSInt(in, shift.abs.U, (shift >= 0).B)
+  out := shiftAndRoundSIntStatic(in, shift)
 }
 
 object UtilityFunctionsTests {
@@ -24,37 +25,24 @@ object UtilityFunctionsTests {
 class UtilityFunctionsTests extends AnyFlatSpec with ChiselScalatestTester {
   behavior.of("utilities")
   import UtilityFunctionsTests.roundModel
-  it should "Test rounding -88 -> -6 and -150 -> -9" in {
-    test(new RoundTestBed(14, -4)) { dut =>
-      dut.in.poke((87).S(14.W))
-      dut.out.expect(roundModel(87, 4).S)
-      dut.in.poke((88).S(14.W))
-      dut.out.expect(roundModel(88, 4).S)
-      dut.in.poke((89).S(14.W))
-      dut.out.expect(roundModel(89, 4).S)
-
-      dut.in.poke((-89).S(14.W))
-      dut.out.expect(roundModel(-89, 4).S)
-      dut.in.poke((-87).S(14.W))
-      dut.out.expect(roundModel(-87, 4).S)
-      dut.in.poke((-88).S(14.W))
-      dut.out.expect(roundModel(-88, 4).S)
-    /*assert(roundModel(-88, 4).S(14.W).litValue.toInt == -6)
-      dut.in.poke((-150).S(14.W))
-      dut.out.expect(roundModel(-150, 4).S)
-      assert(roundModel(-150, 4).S(14.W).litValue.toInt == -9)*/
+  for (number <- Seq(87, 88, 89, -87, -88, -89, -150)) {
+    it should s"Test rounding $number with shift == 4. Should be: ${roundModel(number, 4)}" in {
+      test(new RoundTestBed(14, -4)) { dut =>
+        dut.in.poke(number.S(14.W))
+        dut.out.expect(roundModel(number, 4).S)
+      }
     }
   }
 
   val r = new scala.util.Random
   r.setSeed(42L)
-  val numRandomTests = 500
+  val numRandomTests = 10
   val maxAccumulatorValue = 8191
-  for (_ <- 0 until numRandomTests) {
+  for (idx <- 0 until numRandomTests) {
     val isNegative = r.nextBoolean()
     val value = if (isNegative) -r.nextInt(maxAccumulatorValue) else r.nextInt(maxAccumulatorValue)
-    val shift = r.nextInt(7)
-    it should s"Test random rounding value: $value, shift: $shift" in {
+    val shift = 4
+    it should s"Random test $idx rounding value: $value, shift: 4" in {
       test(new RoundTestBed(14, -shift)) { dut =>
         dut.in.poke(value.S(14.W))
         dut.out.expect(roundModel(value, shift).S)

--- a/chisel4ml/scala/test/UtilityFunctionsTests.scala
+++ b/chisel4ml/scala/test/UtilityFunctionsTests.scala
@@ -48,22 +48,29 @@ class UtilityFunctionsTests extends AnyFlatSpec with ChiselScalatestTester {
       }
     }
   }
+  it should s"Test STATIC shift with acc -5 and shift == 2" in {
+    test(new RoundTestBedStatic(8, -2)) { dut =>
+      dut.in.poke((-5).S(8.W))
+      dut.clock.step()
+      dut.out.expect(roundModel(-5, 2))
+    }
+  }
 
   val r = new scala.util.Random
   r.setSeed(42L)
-  val numRandomTests = 50
+  val numRandomTests = 10
   val maxAccumulatorValue = 8191
   for (idx <- 0 until numRandomTests) {
     val isNegative = r.nextBoolean()
     val value = if (isNegative) -r.nextInt(maxAccumulatorValue) else r.nextInt(maxAccumulatorValue)
-    val shift = 4
-    it should s"Random STATIC test $idx rounding value: $value, shift: 4" in {
+    val shift = r.nextInt(5)
+    it should s"Random STATIC test $idx rounding value: $value, shift: $shift" in {
       test(new RoundTestBedStatic(14, -shift)) { dut =>
         dut.in.poke(value.S(14.W))
         dut.out.expect(roundModel(value, shift).S)
       }
     }
-    it should s"Random DYNAMIC test $idx rounding value: $value, shift: 4" in {
+    it should s"Random DYNAMIC test $idx rounding value: $value, shift: $shift" in {
       test(new RoundTestBedDynamic(14, -shift)) { dut =>
         dut.in.poke(value.S(14.W))
         dut.out.expect(roundModel(value, shift).S)

--- a/chisel4ml/scala/test/UtilityFunctionsTests.scala
+++ b/chisel4ml/scala/test/UtilityFunctionsTests.scala
@@ -3,14 +3,21 @@ package chisel4ml.tests
 import _root_.chisel3._
 import chiseltest._
 import org.scalatest.flatspec.AnyFlatSpec
+import chisel4ml.util.shiftAndRoundSInt
 import chisel4ml.util.shiftAndRoundSIntStatic
 
-class RoundTestBed(inputWidth: Int, shift: Int) extends Module {
+class RoundTestBedStatic(inputWidth: Int, shift: Int) extends Module {
   val in = IO(Input(SInt(inputWidth.W)))
   val out = IO(Output(SInt()))
 
-  //out := shiftAndRoundSInt(in, shift.abs.U, (shift >= 0).B)
   out := shiftAndRoundSIntStatic(in, shift)
+}
+
+class RoundTestBedDynamic(inputWidth: Int, shift: Int) extends Module {
+  val in = IO(Input(SInt(inputWidth.W)))
+  val out = IO(Output(SInt()))
+
+  out := shiftAndRoundSInt(in, shift.abs.U, (shift >= 0).B)
 }
 
 object UtilityFunctionsTests {
@@ -26,9 +33,17 @@ class UtilityFunctionsTests extends AnyFlatSpec with ChiselScalatestTester {
   behavior.of("utilities")
   import UtilityFunctionsTests.roundModel
   for (number <- Seq(87, 88, 89, -87, -88, -89, -150)) {
-    it should s"Test rounding $number with shift == 4. Should be: ${roundModel(number, 4)}" in {
-      test(new RoundTestBed(14, -4)) { dut =>
+    it should s"Test STATIC acc-pos: ${number > 0} rounding $number with shift == 4. Should be: ${roundModel(number, 4)}" in {
+      test(new RoundTestBedStatic(14, -4)) { dut =>
         dut.in.poke(number.S(14.W))
+        dut.clock.step()
+        dut.out.expect(roundModel(number, 4).S)
+      }
+    }
+    it should s"Test DYNAMIC acc-pos: ${number > 0} rounding $number with shift == 4. Should be: ${roundModel(number, 4)}" in {
+      test(new RoundTestBedDynamic(14, -4)) { dut =>
+        dut.in.poke(number.S(14.W))
+        dut.clock.step()
         dut.out.expect(roundModel(number, 4).S)
       }
     }
@@ -36,14 +51,20 @@ class UtilityFunctionsTests extends AnyFlatSpec with ChiselScalatestTester {
 
   val r = new scala.util.Random
   r.setSeed(42L)
-  val numRandomTests = 10
+  val numRandomTests = 50
   val maxAccumulatorValue = 8191
   for (idx <- 0 until numRandomTests) {
     val isNegative = r.nextBoolean()
     val value = if (isNegative) -r.nextInt(maxAccumulatorValue) else r.nextInt(maxAccumulatorValue)
     val shift = 4
-    it should s"Random test $idx rounding value: $value, shift: 4" in {
-      test(new RoundTestBed(14, -shift)) { dut =>
+    it should s"Random STATIC test $idx rounding value: $value, shift: 4" in {
+      test(new RoundTestBedStatic(14, -shift)) { dut =>
+        dut.in.poke(value.S(14.W))
+        dut.out.expect(roundModel(value, shift).S)
+      }
+    }
+    it should s"Random DYNAMIC test $idx rounding value: $value, shift: 4" in {
+      test(new RoundTestBedDynamic(14, -shift)) { dut =>
         dut.in.poke(value.S(14.W))
         dut.out.expect(roundModel(value, shift).S)
       }

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -380,6 +380,7 @@ def sint_simple_model() -> tf.keras.Model:
             bits=4, integer=3, keep_negative=True, alpha=np.array([0.125])
         ),
     )(x)
+    x = qkeras.QActivation(qkeras.quantized_relu(bits=3, integer=3))(x)
     model = tf.keras.Model(inputs=[x_in], outputs=[x])
     model.compile()
     model.layers[2].set_weights([w1, b1])

--- a/tests/test_audio.py
+++ b/tests/test_audio.py
@@ -118,13 +118,10 @@ def test_audio_classifier_no_preproc_1st_layer(
     ts_iter = test_set.as_numpy_iterator()
     for _ in range(100):
         sample, label = next(ts_iter)
-        sw_res = opt_model.layers[3](opt_model.layers[2](sample.reshape(1, 32, 20, 1)))
-        sw_ret = (
-            sw_res / opt_model.layers[2].depthwise_quantizer_internal.scale[0, 0, 0, 0]
-        )
+        sw_ret = opt_model.layers[3](opt_model.layers[2](sample.reshape(1, 32, 20, 1)))
         sw_ret = np.moveaxis(sw_ret.numpy().reshape(30, 18, 2), -1, 0)
         hw_ret = circuit.predict(sample.reshape(1, 32, 20))
-        assert np.array_equal(hw_ret, sw_ret)
+        assert np.allclose(hw_ret, sw_ret, atol=1.0, rtol=0.0)
 
 
 def test_audio_classifier_no_preproc(qnn_audio_class_no_preproc, audio_data_preproc):

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -522,4 +522,4 @@ def test_run_service_digits_20(sint_digit_model_ds):
         image = digits_ds.images[i]
         sw_res = opt_model.predict(image.reshape(1, 8, 8, 1))
         hw_res = circuit.predict(image.reshape(1, 8, 8))
-        assert tf.reduce_all(np.isclose(sw_res, hw_res, atol=1.0))
+        assert np.allclose(sw_res, hw_res, atol=0.0, rtol=0.0)

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -136,12 +136,14 @@ def test_run_service_5(sint_simple_model):
     )
 
     opt_model = optimize.qkeras_model(sint_simple_model)
-    circuit = generate.circuit(opt_model, is_simple=False)
+    circuit = generate.circuit(
+        opt_model, is_simple=False, use_verilator=True, gen_waveform=True
+    )
     assert circuit is not None
     for i in range(0, 10):
         sw_res = opt_model.predict(x_test[i].reshape(1, 3))
         hw_res = circuit(x_test[i])
-        assert tf.reduce_all(np.isclose(sw_res, hw_res, atol=1.0)), (
+        assert tf.reduce_all(tf.math.equal(sw_res, hw_res)), (
             f"The software model predicted the result {sw_res}, where as the hardware"
             f" model predicted {hw_res}. Something is wrong here. The stated results"
             f" are for the inputs {x_test[i]}. "
@@ -522,4 +524,4 @@ def test_run_service_digits_20(sint_digit_model_ds):
         image = digits_ds.images[i]
         sw_res = opt_model.predict(image.reshape(1, 8, 8, 1))
         hw_res = circuit.predict(image.reshape(1, 8, 8))
-        assert np.allclose(sw_res, hw_res, atol=0.0, rtol=0.0)
+        assert np.allclose(sw_res.reshape(10), hw_res, atol=1.0, rtol=0.0)


### PR DESCRIPTION
Fixed the rounding function, however it is still not bit acccurate with quantized_bits,
because of the way quantized_bits is implemented.
I.e., they calculate the scale as such:
        `scale = K.pow(2.0, tf.math.round(K.log(scale + K.epsilon()) / np.log(2.0)))`

This can cause discrepancy because of the use of floating-point arihtmetic (even with epsilon set to zero).
so i.e. if scale == 16, it becomes 15.99997.

The rounding function used by quantized_bits then does the following:
` v = tf.floor((tf.abs(x) / scale) + 0.5) * sign(x)`

this is a problem as instead of `(tf.abs(x) / scale)  +0.5` equaling i.e. 3.0 it can equal 2.9999999, and the floor function simply rounds this down. 

This problem should be addressed by defining new quantization operators that don't suffer from this problem of numeric stability,
and should be defined in the LBIR spec.

A new branch/pull request will be opened for this.