### PR TITLE
Padding support

### DIFF
--- a/chisel4ml/lbir/lbir.proto
+++ b/chisel4ml/lbir/lbir.proto
@@ -82,12 +82,16 @@ message Conv2DConfig {
     QTensor output = 4;
     Activation activation = 5;
     bool depthwise = 7;
+    repeated uint32 stride = 8;
+    repeated uint32 padding = 9;
 }
 
 message MaxPool2DConfig {
     QTensor input = 1;
     QTensor output = 2;
     repeated uint32 kernel_shape = 3;
+    repeated uint32 stride = 4;
+    repeated uint32 padding = 5;
 }
 
 

--- a/chisel4ml/scala/main/combinational/NeuronOperation.scala
+++ b/chisel4ml/scala/main/combinational/NeuronOperation.scala
@@ -21,12 +21,12 @@ import dsptools.{DspContext, Grow}
 
 trait NeuronOperation {
   def apply(
-    qc:      NeuronCompute
-  )(in:      Seq[qc.I],
-    weights: Seq[qc.W],
-    thresh:  qc.A,
+    nc:      NeuronCompute
+  )(in:      Seq[nc.I],
+    weights: Seq[nc.W],
+    thresh:  nc.A,
     shift:   Int
-  ): qc.O
+  ): nc.O
 }
 
 object NeuronWithBias extends NeuronOperation {

--- a/chisel4ml/scala/main/combinational/NeuronProcessingUnit.scala
+++ b/chisel4ml/scala/main/combinational/NeuronProcessingUnit.scala
@@ -41,8 +41,8 @@ class NeuronProcessingUnit(
 
   for (i <- 0 until layer.output.numParams) {
     out(i) := operation(nc)(
-      LayerMapping.getReceptiveField[nc.I](in.map(_.asInstanceOf[nc.I]), inMap(i)),
-      LayerMapping.getReceptiveField[nc.W](kernel, kernelMap(i)),
+      LayerMapping.getReceptiveField[nc.I](in.map(_.asInstanceOf[nc.I]), inMap(i), Some(layer.input.zero[nc.I])),
+      VecInit(LayerMapping.getReceptiveField[nc.W](kernel, kernelMap(i), None)),
       thresh(threshMap(i)),
       shift(shiftMap(i))
     )

--- a/chisel4ml/scala/main/combinational/OrderProcessingUnit.scala
+++ b/chisel4ml/scala/main/combinational/OrderProcessingUnit.scala
@@ -33,6 +33,8 @@ class OrderProcessingUnit(
   val inMap: Seq[Seq[Int]] = LayerMapping.layerToInputMap(layer)
 
   for (i <- 0 until layer.output.numParams) {
-    out(i) := operation(oc)(LayerMapping.getReceptiveField[oc.T](in.map(_.asInstanceOf[oc.T]), inMap(i)))
+    out(i) := operation(oc)(
+      LayerMapping.getReceptiveField[oc.T](in.map(_.asInstanceOf[oc.T]), inMap(i), None, skipPadding = true)
+    )
   }
 }

--- a/chisel4ml/transform.py
+++ b/chisel4ml/transform.py
@@ -31,9 +31,11 @@ import chisel4ml.lbir.lbir_pb2 as lbir
 from chisel4ml.transforms import AddDummyBiasToConv
 from chisel4ml.transforms import AddFFTrealOutputShape
 from chisel4ml.transforms import AddInputOrOutputQTensorToReshape
+from chisel4ml.transforms import AutoPadToPad
 from chisel4ml.transforms import CleanupQTensors
 from chisel4ml.transforms import ExtractQuantizedBiasFromConv
 from chisel4ml.transforms import InputReluQTensorToQTensor
+from chisel4ml.transforms import MergePad
 from chisel4ml.transforms import QONNXToLBIR
 from chisel4ml.transforms import QuantToQTensor
 from chisel4ml.transforms import RemoveFlattenNode
@@ -63,6 +65,8 @@ QONNX_TO_LBIR_TRANSFORMS = [
     UnquantizedOutputToQTensor(),
     InputReluQTensorToQTensor(),
     RemoveFlattenNode(),
+    MergePad(),
+    AutoPadToPad(),
     QONNXToLBIR(),
     CleanupQTensors(),
 ]

--- a/chisel4ml/transforms/__init__.py
+++ b/chisel4ml/transforms/__init__.py
@@ -28,6 +28,8 @@ from chisel4ml.transforms.qonnx_to_lbir import (  # noqa: F401
     AddFFTrealOutputShape,
     RemoveFlattenNode,
     CleanupQTensors,
+    AutoPadToPad,
+    MergePad,
 )
 from chisel4ml.transforms.extract_quantized_bias import (  # noqa: F401
     ExtractQuantizedBiasFromConv,

--- a/chisel4ml/transforms/qonnx_to_lbir.py
+++ b/chisel4ml/transforms/qonnx_to_lbir.py
@@ -1,4 +1,5 @@
 import logging
+from functools import reduce
 
 import numpy as np
 import onnx
@@ -12,6 +13,7 @@ from chisel4ml.transforms.qonnx_utils import _numpy_to_qtensor
 from chisel4ml.transforms.qonnx_utils import _qtensor_to_kwargs
 from chisel4ml.transforms.qonnx_utils import _scale_to_shift
 from chisel4ml.transforms.qonnx_utils import get_lbir_shape
+from chisel4ml.transforms.qonnx_utils import replace_tensor
 from chisel4ml.transforms.transform_conv import transform_conv
 from chisel4ml.transforms.transform_fftreal import transform_fftreal
 from chisel4ml.transforms.transform_lmfe import transform_lmfe
@@ -493,4 +495,98 @@ class CleanupQTensors(Transformation):
             elif suc is not None:
                 self.replace_input(suc[0], node.output[0], node.input[0])
             return model, True
+        return model, False
+
+
+class AutoPadToPad(Transformation):
+    "Transforms padding specified with autopad to more explicit pads."
+
+    def autopad_to_pads(self, model, node, autopad):
+        if autopad == b"VALID":
+            return [0, 0, 0, 0]
+        elif autopad == b"SAME_UPPER" or autopad == b"SAME_LOWER":
+            ishape = model.get_tensor_shape(node.input[0])  # NCHW
+            kshape = model.get_tensor_shape(node.input[1])  # NCHW
+
+            def reduce_shape(shape):
+                return reduce(lambda x, y: x + y, shape)
+
+            assert reduce_shape(ishape) > reduce_shape(
+                kshape
+            ), "Make sure that ishape is indeed the input shape and not kernel shape"
+            stride = onnx.helper.get_node_attr_value(node, "strides")
+            out_width = ishape[-1] // stride[1]
+            out_height = ishape[-2] // stride[0]
+            # This equation is derived from outshape calc eq
+            # see LayerMapping.scala
+            wpt = (out_width - 1) * stride[1] - ishape[-1] + kshape[-1]
+            hpt = (out_height - 1) * stride[0] - ishape[-2] + kshape[-2]
+            hm = hpt // 2
+            wm = wpt // 2
+            he = hpt % 2
+            we = wpt % 2
+            if autopad == b"SAME_UPPER":
+                return [hm, wm, (hm + he), (wm + we)]
+            else:
+                return [(hm + he), (wm + we), hm, wm]
+        else:
+            raise ValueError(f"Value {autopad} not supported.")
+
+    def apply(self, model):
+        for node in model.graph.node:
+            if node.op_type == "Conv" or node.op_type == "MaxPool":
+                has_no_pads = len([x for x in node.attribute if x.name == "pads"]) == 0
+                if has_no_pads:
+                    autopad = onnx.helper.get_node_attr_value(node, "auto_pad")
+                    pads = self.autopad_to_pads(model, node, autopad)
+                    attr = onnx.helper.make_attribute("pads", pads)
+                    node.attribute.append(attr)
+        return model, False
+
+
+class MergePad(Transformation):
+    def transform_pads(self, pads):
+        if len(pads) == 4:
+            return pads
+        if len(pads) == 8:
+            # This must be NCHW -> return should be only for HW (spatial axes)
+            # https://onnx.ai/onnx/operators/onnx__Pad.html
+            # https://onnx.ai/onnx/operators/onnx__Conv.html
+            return [pads[2], pads[3], pads[6], pads[7]]
+        else:
+            raise ValueError
+
+    def apply(self, model):
+        log_err_str = "Failed to merge pad into successor node!"
+        for node in model.graph.node:
+            if node.op_type == "Pad":
+                assert len(node.output) == 1
+                out_node = model.find_consumer(node.output[0])
+                if out_node.op_type in ("Conv", "MaxPool"):
+                    mode = onnx.helper.get_node_attr_value(node, "mode")
+                    if mode != b"constant":
+                        logging.warning(f"{log_err_str} Mode not constant, but {mode}.")
+                        continue
+                    has_const_val = (
+                        len([x for x in node.attribute if x.name == "constant_value"])
+                        > 0
+                    )
+                    if has_const_val:
+                        const_val = onnx.helper.get_node_attr_value(
+                            node, "constant_value"
+                        )
+                        if const_val != 0:
+                            # Currently only supporting padding with zeros
+                            logging.warning(
+                                f"{log_err_str} Constant value not 0, but {const_val}"
+                            )
+                            continue
+                    pads = model.get_initializer(node.input[1])
+                    transformed_pads = self.transform_pads(pads)
+                    pads_attr = onnx.helper.make_attribute("pads", transformed_pads)
+                    org_attr = [x for x in out_node.attribute if x.name == "pads"]
+                    out_node.attribute.remove(org_attr[0])
+                    out_node.attribute.append(pads_attr)
+                    replace_tensor(out_node.input, node.output[0], node.input[0])
+                    model.graph.node.remove(node)
         return model, False

--- a/chisel4ml/transforms/qonnx_to_lbir.py
+++ b/chisel4ml/transforms/qonnx_to_lbir.py
@@ -1,5 +1,4 @@
 import logging
-from functools import reduce
 
 import numpy as np
 import onnx
@@ -507,13 +506,6 @@ class AutoPadToPad(Transformation):
         elif autopad == b"SAME_UPPER" or autopad == b"SAME_LOWER":
             ishape = model.get_tensor_shape(node.input[0])  # NCHW
             kshape = model.get_tensor_shape(node.input[1])  # NCHW
-
-            def reduce_shape(shape):
-                return reduce(lambda x, y: x + y, shape)
-
-            assert reduce_shape(ishape) > reduce_shape(
-                kshape
-            ), "Make sure that ishape is indeed the input shape and not kernel shape"
             stride = onnx.helper.get_node_attr_value(node, "strides")
             out_width = ishape[-1] // stride[1]
             out_height = ishape[-2] // stride[0]

--- a/chisel4ml/transforms/qonnx_utils.py
+++ b/chisel4ml/transforms/qonnx_utils.py
@@ -70,6 +70,8 @@ def _conv2dconfig_to_kwargs(layer: Conv2DConfig):
     kwargs.update(_qtensor_to_kwargs(layer.kernel, key_prefix="kernel_"))
     kwargs["activation"] = _act_to_string_dict[layer.activation]
     kwargs["depthwise"] = layer.depthwise
+    kwargs["stride"] = layer.stride
+    kwargs["padding"] = layer.padding
     return kwargs
 
 
@@ -78,6 +80,8 @@ def _maxpool2dconfig_to_kwargs(layer: MaxPool2DConfig):
     kwargs.update(_qtensor_to_kwargs(layer.input, key_prefix="input_"))
     kwargs.update(_qtensor_to_kwargs(layer.output, key_prefix="output_"))
     kwargs["kernel_shape"] = layer.kernel_shape
+    kwargs["stride"] = layer.stride
+    kwargs["padding"] = layer.padding
     return kwargs
 
 
@@ -153,3 +157,15 @@ def qtensor_to_quantizer(qtensor):
         )
     else:
         return lambda x: binary_quant(x, 1.0)
+
+
+def replace_tensor(tensor_list, old, new):
+    "Replaces the tensor and preservers the order in the list."
+    old_ind = -1
+    for ind, tensor in enumerate(tensor_list):
+        if tensor == old:
+            old_ind = ind
+            break
+    if old_ind == -1:
+        raise ValueError(f"Tensor {old} not in tensor list: {tensor_list}")
+    tensor_list[old_ind] = new

--- a/chisel4ml/transforms/transform_conv.py
+++ b/chisel4ml/transforms/transform_conv.py
@@ -109,6 +109,8 @@ def transform_conv(model: ModelWrapper, node) -> bool:
         ),
         activation=activation,
         depthwise=(groups == channels),
+        stride=onnx.helper.get_node_attr_value(node, "strides"),
+        padding=onnx.helper.get_node_attr_value(node, "pads"),
     )
     for n in (node, weights_node, bias_node, add_node):
         model.graph.node.remove(n)

--- a/chisel4ml/transforms/transform_maxpool.py
+++ b/chisel4ml/transforms/transform_maxpool.py
@@ -50,6 +50,8 @@ def transform_maxpool(model: ModelWrapper, node) -> bool:
         input=input_qtensor,
         output=output_qtensor,
         kernel_shape=onnx.helper.get_node_attr_value(node, "kernel_shape"),
+        stride=onnx.helper.get_node_attr_value(node, "strides"),
+        padding=onnx.helper.get_node_attr_value(node, "pads"),
     )
     model.graph.node.remove(node)
     kwargs = _maxpool2dconfig_to_kwargs(maxpool2dcfg)

--- a/tests/brevitas_models.py
+++ b/tests/brevitas_models.py
@@ -101,7 +101,7 @@ def get_cnn_model(input_size, in_ch):
 
 
 def get_conv_layer_model(
-    input_ch, output_ch, kernel_size, padding, iq, wq, bq, oq, depthwise=False
+    input_ch, output_ch, kernel_size, padding, stride, iq, wq, bq, oq, depthwise=False
 ):
     class ConvLayerModel(Module):
         def __init__(self):
@@ -113,7 +113,7 @@ def get_conv_layer_model(
                 groups=output_ch if depthwise else 1,
                 kernel_size=kernel_size,
                 padding=padding,
-                stride=1,
+                stride=stride,
                 bias=True,
                 weight_quant=CommonWeightQuant,
                 weight_bit_width=wq,
@@ -152,7 +152,7 @@ def get_conv_layer_model(
     return model, input_data
 
 
-def get_maxpool_layer_model(channels, input_size, kernel_size, padding, iq):
+def get_maxpool_layer_model(channels, input_size, kernel_size, padding, stride, iq):
     class MaxPoolLayerModel(Module):
         def __init__(self, input_size):
             super(MaxPoolLayerModel, self).__init__()
@@ -163,7 +163,11 @@ def get_maxpool_layer_model(channels, input_size, kernel_size, padding, iq):
                 scaling_impl_type="const",
                 scaling_init=1 if iq == 1 else 2 ** (iq - 1) - 1,
             )
-            self.maxpool = torch.nn.MaxPool2d(kernel_size=kernel_size, padding=padding)
+            self.maxpool = torch.nn.MaxPool2d(
+                kernel_size=kernel_size,
+                padding=padding,
+                stride=stride,
+            )
             self.out_quant = qnn.QuantIdentity(
                 act_quant=IntActQuant,
                 bit_width=iq,

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -228,16 +228,30 @@ def test_brevitas(request, c4ml_server, model_ishape_data):
 @pytest.mark.parametrize("input_ch", (1, 3))
 @pytest.mark.parametrize("output_ch", (1, 3))
 @pytest.mark.parametrize("kernel_size", ((3, 3), (2, 3)))
-@pytest.mark.parametrize("padding", (0,))
+@pytest.mark.parametrize("padding", (0, "same"))
+@pytest.mark.parametrize("stride", (1, 2))
 @pytest.mark.parametrize("iq", (1, 3))
 @pytest.mark.parametrize("wq", (1, 5))
 @pytest.mark.parametrize("bq", (3, 8))
 @pytest.mark.parametrize("oq", (1, 4))
 def test_combinational_conv(
-    request, c4ml_server, input_ch, output_ch, kernel_size, padding, iq, wq, bq, oq
+    request,
+    c4ml_server,
+    input_ch,
+    output_ch,
+    kernel_size,
+    padding,
+    stride,
+    iq,
+    wq,
+    bq,
+    oq,
 ):
+    if padding != 0 and iq == 1:
+        # this is an illegal combination binary type has no zero to pad!
+        return
     model, data = get_conv_layer_model(
-        input_ch, output_ch, kernel_size, padding, iq, wq, bq, oq
+        input_ch, output_ch, kernel_size, padding, stride, iq, wq, bq, oq
     )
     accelerators, lbir_model = generate.accelerators(
         model,
@@ -268,15 +282,35 @@ def test_combinational_conv(
 @pytest.mark.parametrize("output_ch", (3,))
 @pytest.mark.parametrize("kernel_size", ((3, 3), (2, 3)))
 @pytest.mark.parametrize("padding", (0,))
+@pytest.mark.parametrize("stride", (1,))
 @pytest.mark.parametrize("iq", (1, 3))
 @pytest.mark.parametrize("wq", (1, 5))
 @pytest.mark.parametrize("bq", (3, 8))
 @pytest.mark.parametrize("oq", (1, 4))
 def test_combinational_conv_dw(
-    request, c4ml_server, input_ch, output_ch, kernel_size, padding, iq, wq, bq, oq
+    request,
+    c4ml_server,
+    input_ch,
+    output_ch,
+    kernel_size,
+    padding,
+    stride,
+    iq,
+    wq,
+    bq,
+    oq,
 ):
     model, data = get_conv_layer_model(
-        input_ch, output_ch, kernel_size, padding, iq, wq, bq, oq, depthwise=True
+        input_ch,
+        output_ch,
+        kernel_size,
+        padding,
+        stride,
+        iq,
+        wq,
+        bq,
+        oq,
+        depthwise=True,
     )
     accelerators, lbir_model = generate.accelerators(
         model,
@@ -312,13 +346,14 @@ def test_combinational_conv_dw(
     ),
 )
 @pytest.mark.parametrize("kernel_size", ((3, 3), (2, 3)))
-@pytest.mark.parametrize("padding", (0,))
+@pytest.mark.parametrize("padding", (0, 1))
+@pytest.mark.parametrize("stride", (1,))
 @pytest.mark.parametrize("iq", (1, 3))
 def test_combinational_maxpool(
-    request, c4ml_server, input_size, channels, kernel_size, padding, iq
+    request, c4ml_server, input_size, channels, kernel_size, padding, stride, iq
 ):
     model, data = get_maxpool_layer_model(
-        channels, input_size, kernel_size, padding, iq
+        channels, input_size, kernel_size, padding, stride, iq
     )
     accelerators, lbir_model = generate.accelerators(
         model,


### PR DESCRIPTION
Added padding support for Conv and MaxPool ops.
The support is general, and the padding need not be symmetric.
The support was added to LBIR and the combinational generators.