### PR TITLE
Removed signal handlers from c4ml python server handler.

### DIFF
--- a/chisel4ml/chisel4ml_server.py
+++ b/chisel4ml/chisel4ml_server.py
@@ -10,7 +10,6 @@
 # limitations under the License.
 import atexit
 import logging
-import signal
 
 import grpc
 
@@ -57,8 +56,6 @@ class Chisel4mlServer:
 
         # Here we make sure that the chisel4ml server is shut down.
         atexit.register(self.stop)
-        signal.signal(signal.SIGTERM, self.stop)
-        signal.signal(signal.SIGINT, self.stop)
 
     @property
     def temp_dir(self):


### PR DESCRIPTION
Signal handlers can't be run outside the main thread, which makes them awkward to work with.
Removing them and putting the burden of closing the channel on the programmer.